### PR TITLE
Fix require's file name case for case-sensitive filesystems

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import Server from './server';
-import Resource from './Resource';
-import Func from './Function';
+import Resource from './resource';
+import Func from './function';
 
 const server = function server(db, prefix) {
   return new Server(db, prefix);

--- a/src/server.js
+++ b/src/server.js
@@ -3,7 +3,7 @@ import bodyParser from 'body-parser';
 import methodOverride from 'method-override';
 import mongoose from 'mongoose';
 import cors from 'cors';
-import Resource from './Resource';
+import Resource from './resource';
 
 function checkAuth(auth, req) {
   return !auth || auth(req);


### PR DESCRIPTION
This should fix the issue https://github.com/TossShinHwa/node-odata/issues/46

In Linux environment, the filesystem are case sensitive and the library wasn't working because of this `require(...)` statements.