### PR TITLE
`contains` function parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npm install node-odata
     * [ ] has
   * [ ] String Functions
   	* [x] indexof
-  	* [ ] contains
+  	* [x] contains
   	* [ ] endswith
   	* [ ] startswith
   	* [ ] length

--- a/src/parser/filterParser.js
+++ b/src/parser/filterParser.js
@@ -87,7 +87,7 @@ export default (query, $filter) => new Promise((resolve, reject) => {
 
     // function query
     const functionKey = key.substring(0, key.indexOf('('));
-    if (functionKey in { indexof: 1, year: 1 }) {
+    if (functionKey in { indexof: 1, year: 1, contains: 1 }) {
       functions[functionKey](query, key, odataOperator, val);
     } else {
     // operator query

--- a/src/parser/functionsParser.js
+++ b/src/parser/functionsParser.js
@@ -67,4 +67,11 @@ const year = (query, fnKey, odataOperator, value) => {
   }
 };
 
-export default { indexof, year };
+// contains(CompanyName,'icrosoft')
+const contains = (query, fnKey, odataOperator, value) => {
+  let [key, target] = fnKey.substring(fnKey.indexOf('(') + 1, fnKey.indexOf(')')).split(',');
+  [key, target] = [key.trim(), target.trim()];
+  query.$where(`this.${key}.indexOf(${target}) != -1`);
+};
+
+export default { indexof, year, contains };


### PR DESCRIPTION
I am using `node-odata` for a project in my work and I needed to query:
`/products?$filter=contains(name,'something')`

I managed to get it work. I didn't know how to add an unary operator (now, the query is like `/products?$filter=contains(name,'something') eq 1`, horrible), but at least it works.

Can you help me to make it an unary operator?
Thanks!