### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "express": "4.14.0",
     "body-parser": "1.15.2",
-    "method-override": "2.3.6",
     "cors": "2.7.1",
+    "express": "4.14.0",
+    "method-override": "2.3.6",
     "mongoose": "4.5.9",
-    "node-uuid": "1.4.7"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "babel": "6.5.2",

--- a/src/model/idPlugin.js
+++ b/src/model/idPlugin.js
@@ -1,4 +1,4 @@
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 
 /*eslint-disable */
 export default function (schema) {

--- a/test/rest.put.js
+++ b/test/rest.put.js
@@ -1,4 +1,4 @@
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import 'should';
 import request from 'supertest';
 import { odata, conn, host, port, bookSchema, initData } from './support/setup';


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.